### PR TITLE
Fix Firefox box sizing problem

### DIFF
--- a/src/css/components/global.less
+++ b/src/css/components/global.less
@@ -113,7 +113,6 @@ span.MessageStatusIcon {
     }
 
     .content {
-        height: 100%;
 
         .source {
             width: 100%;

--- a/src/css/index.less
+++ b/src/css/index.less
@@ -181,11 +181,6 @@ section.TilesSections {
     }
 }
 
-.tiles .window4-mount {
-    grid-column: 1 / span 2;
-    grid-row: 2;
-}
-
 input.invalid, textarea.invalid {
     border: 1px solid red;
 }


### PR DESCRIPTION
(some intermediate state along with height 100% has
been producing strange behavior when a click on 'tweak'
or 'help' kept increasing tile height.