### PR TITLE
Removed useless config from MultiWordGeo tile

### DIFF
--- a/src/js/tiles/core/multiWordGeoAreas/index.ts
+++ b/src/js/tiles/core/multiWordGeoAreas/index.ts
@@ -42,8 +42,6 @@ export interface MultiWordGeoAreasTileConf extends TileConf {
     fpage:number;
     fttIncludeEmpty:boolean;
     areaCodeMapping:{[name:string]:string};
-    areaDiscFillColor:string;
-    areaDiscTextColor:string;
     posQueryGenerator:[string, string];
 }
 
@@ -97,8 +95,6 @@ export class MultiWordGeoAreasTile implements ITileProvider {
                 fpage: conf.fpage,
                 fttIncludeEmpty: conf.fttIncludeEmpty,
                 fmaxitems: 100,
-                areaDiscFillColor: conf.areaDiscFillColor,
-                areaDiscTextColor: conf.areaDiscTextColor,
                 isAltViewMode: false,
                 concIds: Immutable.List(lemmas.map(_ => null)),
                 posQueryGenerator: conf.posQueryGenerator,

--- a/src/js/tiles/core/multiWordGeoAreas/messages.json
+++ b/src/js/tiles/core/multiWordGeoAreas/messages.json
@@ -4,17 +4,20 @@
         "multi_word_geolocations__map_legend": "Relative occurences",
         "multi_word_geolocations__swipe_horizontally_to_view_map": "Swipe a finger horizontally to scroll the map",
         "multi_word_geolocations__table_heading_area": "Area",
-        "multi_word_geolocations__table_heading_freq": "Occurence",
-        "multi_word_geolocations__table_heading_freq_abs": "Absolute",
-        "multi_word_geolocations__table_heading_freq_rel": "Relative"
+        "multi_word_geolocations__table_heading_total_occurrence": "Total occurrence",
+        "multi_word_geolocations__table_heading_occurrence_of_{word}": "Occurrence of \"{word}\"",
+        "multi_word_geolocations__table_heading_freq": "Occurrence",
+        "multi_word_geolocations__table_heading_freq_abs": "abs.",
+        "multi_word_geolocations__table_heading_freq_rel": "rel. [ipm]"
     },
     "cs-CZ": {
         "multi_word_geolocations__main_label": "Geografické oblasti",
         "multi_word_geolocations__map_legend": "Relativní výskyt",
         "multi_word_geolocations__swipe_horizontally_to_view_map": "Pro posun mapy potáhněte prstem horizontálně",
         "multi_word_geolocations__table_heading_area": "Oblast",
-        "multi_word_geolocations__table_heading_freq": "Výskyt",
-        "multi_word_geolocations__table_heading_freq_abs": "Absolutní",
-        "multi_word_geolocations__table_heading_freq_rel": "Relativní"
+        "multi_word_geolocations__table_heading_total_occurrence": "Celkový výskyt",
+        "multi_word_geolocations__table_heading_occurrence_of_{word}": "Výskyt slova \"{word}\"",
+        "multi_word_geolocations__table_heading_freq_abs": "abs.",
+        "multi_word_geolocations__table_heading_freq_rel": "rel. [ipm]"
     }
 }

--- a/src/js/tiles/core/multiWordGeoAreas/model.ts
+++ b/src/js/tiles/core/multiWordGeoAreas/model.ts
@@ -79,8 +79,6 @@ export interface MultiWordGeoAreasModelState extends FreqBarModelStateBase {
     areaCodeMapping:Immutable.Map<string, string>;
     tooltipArea:{tooltipX:number; tooltipY:number, caption: string, data:TooltipValues}|null;
     mapSVG:string;
-    areaDiscFillColor:string;
-    areaDiscTextColor:string;
     isAltViewMode:boolean;
     posQueryGenerator:[string, string];
 }

--- a/src/js/tiles/core/multiWordGeoAreas/views/index.tsx
+++ b/src/js/tiles/core/multiWordGeoAreas/views/index.tsx
@@ -129,21 +129,16 @@ export function init(dispatcher:IActionDispatcher, ut:ViewUtils<GlobalComponents
             <table className="DataTable data cnc-table">
                 <thead>
                     <tr>
-                        <th colSpan={3}></th>
-                        {props.data.map((targetData, target) => <th key={target} colSpan={2}>{props.lemmas.get(target).word}</th>)}
+                        <th rowSpan={2}>{ut.translate('multi_word_geolocations__table_heading_area')}</th>
+                        <th colSpan={2}>{ut.translate('multi_word_geolocations__table_heading_total_occurrence')}</th>
+                        {props.data.map((targetData, target) => <th key={target} colSpan={2}>{ut.translate('multi_word_geolocations__table_heading_occurrence_of_{word}', {word: props.lemmas.get(target).word})}</th>)}
                     </tr>
                     <tr>
-                        <th></th>
-                        <th colSpan={2}>{ut.translate('multi_word_geolocations__table_heading_freq')}</th>
-                        {props.data.map((targetData, target) => <th key={target} colSpan={2}>{ut.translate('multi_word_geolocations__table_heading_freq')}</th>)}
-                    </tr>
-                    <tr>
-                        <th>{ut.translate('multi_word_geolocations__table_heading_area')}</th>
-                        <th key={`totalipm`}>{ut.translate('multi_word_geolocations__table_heading_freq_rel')} [ipm]</th>
-                        <th key={`totalabs`}>{ut.translate('multi_word_geolocations__table_heading_freq_abs')}</th>
+                        <th key={`totalIpm`}>{ut.translate('multi_word_geolocations__table_heading_freq_rel')}</th>
+                        <th key={`totalAbs`}>{ut.translate('multi_word_geolocations__table_heading_freq_abs')}</th>
                         {props.data.flatMap((targetData, target) => [
-                            <th key={`${target}ipm`}>{ut.translate('multi_word_geolocations__table_heading_freq_rel')} [ipm]</th>,
-                            <th key={`${target}abs`}>{ut.translate('multi_word_geolocations__table_heading_freq_abs')}</th>
+                            <th key={`${target}Ipm`}>{ut.translate('multi_word_geolocations__table_heading_freq_rel')}</th>,
+                            <th key={`${target}Abs`}>{ut.translate('multi_word_geolocations__table_heading_freq_abs')}</th>
                         ])}
                     </tr>
                 </thead>
@@ -151,16 +146,16 @@ export function init(dispatcher:IActionDispatcher, ut:ViewUtils<GlobalComponents
                     {groupedAreaData.sortBy((rows, area) => area, (a, b) => a.localeCompare(b)).entrySeq().map(([area, rows]) =>
                         <tr key={area}>
                             <td key={area}>{area}</td>
-                            <td key={`${area}totalipm`} className="num">{groupedAreaIpmNorms.get(area).toFixed(2)}</td>
-                            <td key={`${area}totalabs`} className="num">{groupedAreaAbsFreqs.get(area)}</td>
+                            <td key={`${area}Ipm`} className="num">{groupedAreaIpmNorms.get(area).toFixed(2)}</td>
+                            <td key={`${area}Abs`} className="num">{groupedAreaAbsFreqs.get(area)}</td>
                             {props.data.flatMap((targetData, target) => {
                                 const row = rows.find(row => row.target === target);
                                 return row ? [
-                                    <td key={`${area}${target}ipm`} className="num">{row.ipm}<br/>({(100*row.ipm/groupedAreaIpmNorms.get(area)).toFixed(2)}%)</td>,
-                                    <td key={`${area}${target}abs`} className="num">{row.freq}</td>
+                                    <td key={`${area}${target}Ipm`} className="num">{row.ipm}<br/>({(100*row.ipm/groupedAreaIpmNorms.get(area)).toFixed(2)}%)</td>,
+                                    <td key={`${area}${target}Abs`} className="num">{row.freq}</td>
                                 ] : [
-                                    <td key={`${area}${target}ipm`}></td>,
-                                    <td key={`${area}${target}abs`}></td>
+                                    <td key={`${area}${target}Ipm`}></td>,
+                                    <td key={`${area}${target}Abs`}></td>
                                 ]
                             })}
                         </tr>


### PR DESCRIPTION
Example config:
```
		"MultiWordSpeakerArea": {
			"tileType": "MultiWordGeoAreasTile",
			"label": {
				"cs-CZ": "Nářeční oblasti",
				"en-US": "Dialect areas"
			},
			"apiURL": "/kontext",
			"corpname": "oral_v1",
			"fcrit": "sp.reg_childhood 0",
			"flimit": 1,
			"freqSort": "rel",
			"fpage": 1,
			"fttIncludeEmpty": false,
			"areaCodeMapping": {
				"středočeská": "naSTR",
				"severovýchodočeská": "naSVC",
				"středomoravská": "naSTM",
				"pohraničí české": "naCPO",
				"východomoravská": "naVYM",
				"západočeská": "naZAC",
				"jihočeská": "naJIC",
				"slezská": "naSLE",
				"česko-moravská": "naCMO",
				"pohraničí moravské": "naMPO",
				"zahraničí": "naFRG",
				"neznámé": "naUNK"
			},
			"posQueryGenerator": [
				"tag",
				"ppTagset"
			]
		},
```