### PR TITLE
Improve streaming for dependent tiles -

### DIFF
--- a/src/js/page/streaming.ts
+++ b/src/js/page/streaming.ts
@@ -384,7 +384,14 @@ export class DataStreaming implements IDataStreaming {
         );
         return this.responseStream.pipe(
             filter(
-                (response:EventItem<T>) => response.tileId === normEntry.tileId && response.queryIdx === normEntry.queryIdx
+                (response:EventItem<T>) => {
+                    if (isOtherTileRequest(normEntry)) {
+                        return response.tileId === normEntry.otherTileId && response.queryIdx === normEntry.otherTileQueryIdx;
+
+                    } else {
+                        return response.tileId === normEntry.tileId && response.queryIdx === normEntry.queryIdx;
+                    }
+                }
             ),
             map(response => {
                 if (response.error) {

--- a/src/js/tiles/core/colloc/api.ts
+++ b/src/js/tiles/core/colloc/api.ts
@@ -120,20 +120,21 @@ export class MQueryCollAPI implements ResourceApi<MQueryCollArgs, CollApiRespons
         )
     }
 
-    private prepareCollWithExArgs(queryArgs:MQueryCollArgs):string {
+    private prepareCollWithExArgs(queryArgs:MQueryCollArgs, event:string):string {
         return this.prepareArgs({
             ...queryArgs,
-            examplesPerColl: 2
+            examplesPerColl: 2,
+            event
         });
     }
 
-    private mkUrl(args:MQueryCollArgs):string {
+    private mkUrl(args:MQueryCollArgs, event:string):string {
         return this.useWithExamplesVariant ?
             urlJoin(
                 this.apiURL,
                 'collocations-with-examples',
                 args.corpusId
-            ) + `?${this.prepareCollWithExArgs(args)}` :
+            ) + `?${this.prepareCollWithExArgs(args, event)}` :
             urlJoin(
                 this.apiURL,
                 'collocations',
@@ -148,8 +149,9 @@ export class MQueryCollAPI implements ResourceApi<MQueryCollArgs, CollApiRespons
                     tileId,
                     queryIdx,
                     method: HTTP.Method.GET,
-                    url: args ? this.mkUrl(args) : '',
+                    url: args ? this.mkUrl(args, `DataTile-${tileId}.${queryIdx}`) : '',
                     body: {},
+                    isEventSource: this.useWithExamplesVariant,
                     contentType: 'application/json',
                 }
             ).pipe(

--- a/src/js/tiles/core/concordance/index.ts
+++ b/src/js/tiles/core/concordance/index.ts
@@ -63,7 +63,7 @@ export class ConcordanceTile implements ITileProvider {
 
     constructor({
         tileId, dispatcher, appServices, ut, queryType, queryMatches,
-        widthFract, conf, isBusy, useDataStream, readDataFromTile
+        widthFract, conf, isBusy, readDataFromTile
     }:TileFactoryArgs<ConcordanceTileConf>
     ) {
         this.tileId = tileId;

--- a/src/js/tiles/core/concordance/model.ts
+++ b/src/js/tiles/core/concordance/model.ts
@@ -464,7 +464,9 @@ export class ConcordanceTileModel extends StatefulModel<ConcordanceTileState> {
                 streaming.registerTileRequest<collWithExamplesResponse>(
                     {
                         tileId: this.tileId,
+                        queryIdx: 0, // TODO
                         otherTileId: this.readDataFromTile,
+                        otherTileQueryIdx: 0, // TODO
                         contentType: 'application/json',
                     }
                 ).pipe(


### PR DESCRIPTION
now they read directly from data belonging to their "source" tile. This means that APIGuard does not have to duplicate responses of main tiles to the dependent ones.